### PR TITLE
try removing the latest version to see if it's a node thing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14]
+        node-version: [12, 14, 16]
         # https://github.com/actions/setup-node#supported-version-syntax
 
     steps:
@@ -60,5 +60,3 @@ jobs:
         if: always() # always run even if the previous step fails
         with:
           report_paths: reports/jest-node*/*.xml
-      # - run: docker-compose down
-      #   if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [12, 14]
         # https://github.com/actions/setup-node#supported-version-syntax
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           CACHE_KEY: npm-cache-key-node-v${{ matrix.node-version }}
       - run: npm ci
-      - run: docker-compose up -d
+      - run: docker compose up -d
       - name: Test
         run: npm test -- --ci --runInBand --reporters=default --reporters=jest-junit
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,5 @@ jobs:
         if: always() # always run even if the previous step fails
         with:
           report_paths: reports/jest-node*/*.xml
-      - run: docker-compose down
-        if: always()
+      # - run: docker-compose down
+      #   if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ version: '3'
 
 services:
   database:
-    image: postgres:14-alpine
+    image: postgres:12-alpine
     ports:
       - 5432:5432
     env_file:
       - .db.env
-    # tmpfs:
-    #   - /var/lib/postgresql/data
+    tmpfs:
+      - /var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   database:
-    image: postgres:13-alpine
+    image: postgres:10.5-alpine
     ports:
       - 5432:5432
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   database:
-    image: postgres:13-alpine
+    image: circleci/postgres:alpine-ram
     ports:
       - 5432:5432
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   database:
-    image: postgres:12-alpine
+    image: postgres:13-alpine
     ports:
       - 5432:5432
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   database:
-    image: postgres:10.5-alpine
+    image: postgres:11-alpine
     ports:
       - 5432:5432
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,5 @@ services:
       - 5432:5432
     env_file:
       - .db.env
-    tmpfs:
-      - /var/lib/postgresql/data
+    # tmpfs:
+    #   - /var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   database:
-    image: postgres:11-alpine
+    image: postgres:12-alpine
     ports:
       - 5432:5432
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   database:
-    image: postgres:13-alpine
+    image: postgres:14-alpine
     ports:
       - 5432:5432
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   database:
-    image: circleci/postgres:alpine-ram
+    image: postgres:13-alpine
     ports:
       - 5432:5432
     env_file:

--- a/knexfile.js
+++ b/knexfile.js
@@ -11,5 +11,8 @@ module.exports = {
   },
   seeds: {
     directory: 'tests/seeds'
+  },
+  pool: {
+    min: 0
   }
 }

--- a/knexfile.js
+++ b/knexfile.js
@@ -11,8 +11,5 @@ module.exports = {
   },
   seeds: {
     directory: 'tests/seeds'
-  },
-  pool: {
-    min: 0
   }
 }


### PR DESCRIPTION
GItHub Actions reliably fails, saying "Connection terminated unexpectedly". At first, I thought the CI was calling `docker-compose down` after one of the tests was over, causing the others to lose connection; however, this doesn't seem to be the case.

I've also ruled out tmpfs and docker-compose v1 vs v2 as a reason why it might be locally but not in Actions as well.

For whatever reason, in the official Postgres v13 image, they introduced a regression where it just... fucking refuses and/or drops connection in the CI, again reliably so.

For now, I'm pinning it to v12 but this is fucking bullshit of a solution.